### PR TITLE
Fixed story ../../index.css not found error while running storybook

### DIFF
--- a/src/stories/index.jsx
+++ b/src/stories/index.jsx
@@ -8,7 +8,6 @@ import InfinityTableReadme from '../components/Table/InfinityTable/README.md';
 import PageTable from './Table/PageTable';
 import PageTableReadme from '../components/Table/PageTable/README.md';
 import './index.css';
-import '../../index.css'
 
 storiesOf('Table', module)
   .addDecorator(withReadme([SumTableReadme]))


### PR DESCRIPTION
After cloning the code and installing dependencies, when we run yarn run storybook to see expamples, it fails during build due to file not found error.

This PR fixes it.